### PR TITLE
Retry making queries when the token is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Note that our SDK currently depends on RxSwift packages which are automatically 
 # 2. Install the RealifeTech-CoreSDK Pod dependency
 Add the following line to your .podfile under your Apps target:
 ```
-pod 'RealifeTech-CoreSDK', '~> 1.0.3'
+pod 'RealifeTech-CoreSDK', '~> 1.0.4'
 ```
 Open your terminal, navigate to the directory containing your podfile, and run:
 ```

--- a/RealifeTech-CoreSDK.podspec
+++ b/RealifeTech-CoreSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "RealifeTech-CoreSDK"
-  spec.version      = "1.0.3"
+  spec.version      = "1.0.4"
   spec.summary      = "Providing the core services with the RealifeTech Experience Automation Platform."
 
   spec.description  = "This is RealifeTech Core SDK, it provides the core services with RealifeTech backend services. Creating a better experience of the real world for every person."

--- a/RealifeTech-CoreSDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-CoreSDK.xcodeproj/project.pbxproj
@@ -1163,7 +1163,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.concertlive.RealifeTech-CoreSDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1191,7 +1191,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.concertlive.RealifeTech-CoreSDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/RealifeTech-CoreSDK/APIV3Utilities/APIV3Requester.swift
+++ b/RealifeTech-CoreSDK/APIV3Utilities/APIV3Requester.swift
@@ -17,9 +17,14 @@ public protocol APIV3Requester: JSONContentTypeHeaderRequestInserting, DeviceIdH
 }
 
 extension APIV3Requester {
+
     public static func preDispatchAction() -> Observable<Any?>? {
-        return APIV3RequesterHelper.tokenManager.getTokenObservable?.map {
-            $0 as Any
+        return .create { observer in
+            APIV3RequesterHelper.tokenManager.getValidToken {
+                observer.onNext(())
+                observer.onCompleted()
+            }
+            return Disposables.create()
         }
     }
 
@@ -45,6 +50,7 @@ extension APIV3Requester {
 }
 
 extension APIV3Requester {
+
     static func format(date: Date, format: String? = nil) -> String {
         let dateFormat = format ?? dateFormatString()
         let formatter = DateFormatter()

--- a/RealifeTech-CoreSDK/APIV3Utilities/OAuthRepository/OAuthRepository.swift
+++ b/RealifeTech-CoreSDK/APIV3Utilities/OAuthRepository/OAuthRepository.swift
@@ -11,6 +11,7 @@ import RxSwift
 
 protocol OAuthProviding {
     static func requestInitialAccessToken() -> Observable<OAuthToken>
+    static func refreshAccessToken(_ refreshToken: String) -> Observable<OAuthToken>
 }
 
 struct OAuthRepository: RemoteDiskCacheDataProviding {
@@ -19,7 +20,12 @@ struct OAuthRepository: RemoteDiskCacheDataProviding {
 }
 
 extension OAuthRepository: OAuthProviding {
+
     static func requestInitialAccessToken() -> Observable<OAuthToken> {
         return retrieve(type: Cdble.self, forRequest: Rqstr.requestInitialAccessToken(), strategy: .remoteWithoutCachingResponse)
+    }
+
+    static func refreshAccessToken(_ refreshToken: String) -> Observable<OAuthToken> {
+        return retrieve(type: Cdble.self, forRequest: Rqstr.refreshAccessToken(refreshToken), strategy: .remoteWithoutCachingResponse)
     }
 }

--- a/RealifeTech-CoreSDK/APIV3Utilities/Tests/APIV3RequesterTests.swift
+++ b/RealifeTech-CoreSDK/APIV3Utilities/Tests/APIV3RequesterTests.swift
@@ -94,11 +94,6 @@ final class APIV3RequesterTests: XCTestCase  {
         }))
     }
 
-    func test_preDispatchAction_none() {
-        testTokenManager.getTokenObservable = nil
-        XCTAssertNil(MockRequester.preDispatchAction())
-    }
-
     func test_preDispatchAction_some() {
         let bag = DisposeBag()
         let source = PublishSubject<Void>()
@@ -123,9 +118,15 @@ private final class MockTokenManager: V3APITokenManagable {
 
     var token: String?
     var tokenIsValid: Bool = false
+    var refreshToken: String?
+    var refreshTokenIsValid: Bool = false
     var getTokenObservable: Observable<Void>?
 
     func getValidToken(_ completion: (() -> Void)?) {
         completion?()
     }
+
+    func storeCredentials(accessToken: String, secondsExpiresIn: Int, refreshToken: String?) { }
+
+    func removeCredentials() { }
 }

--- a/RealifeTech-CoreSDK/APIV3Utilities/Tests/AuthorisationWorkerTests.swift
+++ b/RealifeTech-CoreSDK/APIV3Utilities/Tests/AuthorisationWorkerTests.swift
@@ -50,14 +50,14 @@ final class AuthorisationWorkerTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 0.1)
-        guard let(resultToken, resultExpiry) = storeSpy.savedCredentials else {
+        guard let(resultToken, resultExpiry, _) = storeSpy.savedCredentials else {
             return XCTFail("No token details saved to store")
         }
         XCTAssertEqual(resultToken, testTokenString)
         XCTAssertEqual(resultExpiry, testExpirySeconds)
     }
 
-    private func emitInitialAccessToken(initialToken: OAuthToken, completion: @escaping (OAuthToken) -> ()) {
+    private func emitInitialAccessToken(initialToken: OAuthToken, completion: @escaping (OAuthToken) -> Void) {
         let observable = sut.requestInitialAccessToken
         observable
             .subscribe(onNext: { token in
@@ -66,13 +66,56 @@ final class AuthorisationWorkerTests: XCTestCase {
             }).disposed(by: disposeBag)
         MockOAuthRepository.accessTokenSource.onNext(initialToken)
     }
+
+    func test_refreshAccessToken_hasRefreshTokenAndAccessTokenIsExpired_tokenIsStored() {
+        storeSpy.accessTokenValid = false
+        storeSpy.accessToken = testTokenString
+        storeSpy.refreshToken = testTokenString
+        let testOAuthToken = OAuthToken(
+            accessToken: testTokenString,
+            refreshToken: testTokenString,
+            expiresIn: testExpirySeconds,
+            tokenType: nil,
+            scope: nil)
+        let expectation = XCTestExpectation(description: "OAuth observable did emit value")
+        emitRefreshAccessToken(initialToken: testOAuthToken) { [self] token in
+            XCTAssertEqual(storeSpy.savedCredentials?.0, testTokenString)
+            XCTAssertEqual(storeSpy.savedCredentials?.1, testExpirySeconds)
+            XCTAssertEqual(storeSpy.savedCredentials?.2, testTokenString)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func test_refreshAccessToken_hasNoRefreshToken_returnNilObservable() {
+        storeSpy.accessTokenValid = false
+        storeSpy.accessToken = testTokenString
+        storeSpy.refreshToken = nil
+        XCTAssertNil(sut.refreshAccessToken)
+    }
+
+    private func emitRefreshAccessToken(initialToken: OAuthToken, completion: @escaping (OAuthToken) -> Void) {
+        let observable = sut.refreshAccessToken
+        observable?
+            .subscribe(onNext: { token in
+                XCTAssertEqual(token, initialToken)
+                completion(token)
+            }).disposed(by: disposeBag)
+        MockOAuthRepository.refreshAccessTokenSource.onNext(initialToken)
+    }
 }
 
 private struct MockOAuthRepository: OAuthProviding {
+
     static let accessTokenSource = PublishSubject<OAuthToken>()
+    static let refreshAccessTokenSource = PublishSubject<OAuthToken>()
 
     static func requestInitialAccessToken() -> Observable<OAuthToken> {
         return accessTokenSource.asObservable()
+    }
+
+    static func refreshAccessToken(_ refreshToken: String) -> Observable<OAuthToken> {
+        return refreshAccessTokenSource.asObservable()
     }
 }
 
@@ -80,10 +123,12 @@ private final class MockAuthorisationStore: AuthorisationStoring {
 
     var accessToken: String?
     var accessTokenValid: Bool = false
-    var savedCredentials: (String, Int)?
+    var refreshToken: String?
+    var refreshTokenValid: Bool = false
+    var savedCredentials: (String, Int, String?)?
 
-    func saveCredentials(token: String, secondsExpiresIn: Int) {
-        self.savedCredentials = (token, secondsExpiresIn)
+    func saveCredentials(token: String, secondsExpiresIn: Int, refreshToken: String?) {
+        self.savedCredentials = (token, secondsExpiresIn, refreshToken)
     }
 
     func removeCredentials() {}

--- a/RealifeTech-CoreSDK/APIV3Utilities/Tests/OAuthRefreshOrWaitActionGeneratorTests.swift
+++ b/RealifeTech-CoreSDK/APIV3Utilities/Tests/OAuthRefreshOrWaitActionGeneratorTests.swift
@@ -129,17 +129,21 @@ private final class MockStore: AuthorisationStoring {
 
     var accessToken: String?
     var accessTokenValid: Bool = false
+    var refreshToken: String?
+    var refreshTokenValid: Bool = false
 
-    func saveCredentials(token: String, secondsExpiresIn: Int) {}
+    func saveCredentials(token: String, secondsExpiresIn: Int, refreshToken: String?) {}
     func removeCredentials() {}
 }
 
 private final class MockWorker: AuthorisationWorkable {
 
     var requestInitialAccessToken: Observable<OAuthToken>
+    var refreshAccessToken: Observable<OAuthToken>?
 
     init(oAuthTokenObservable: Observable<OAuthToken>) {
         self.requestInitialAccessToken = oAuthTokenObservable
+        self.refreshAccessToken = nil
     }
 }
 

--- a/RealifeTech-CoreSDK/APIV3Utilities/V3APITokenManager/OAuthTokenHelpers/AuthorisationStore.swift
+++ b/RealifeTech-CoreSDK/APIV3Utilities/V3APITokenManager/OAuthTokenHelpers/AuthorisationStore.swift
@@ -54,7 +54,7 @@ struct AuthorisationStore: AuthorisationStoring {
 
     func saveCredentials(token: String, secondsExpiresIn: Int, refreshToken: String?) {
         update(accessToken: token, withSecondsExpiresIn: secondsExpiresIn)
-        update(refreshToken: refreshToken)
+        update(refreshToken: refreshToken, withSecondsExpiresIn: secondsExpiresIn)
     }
 
     func removeCredentials() {
@@ -70,10 +70,10 @@ struct AuthorisationStore: AuthorisationStoring {
         keychain.set(expiryDate, forKey: KeychainKey.expiryDate.rawValue)
     }
 
-    private func update(refreshToken: String?) {
+    private func update(refreshToken: String?, withSecondsExpiresIn seconds: Int?) {
         guard let refreshToken = refreshToken else { return }
         keychain.set(refreshToken, forKey: KeychainKey.refreshToken.rawValue)
-        let nearlyFourteenDaysInSeconds = 1166400
+        let nearlyFourteenDaysInSeconds = seconds ?? 1166400
         let expiryDate = "\(Date().addingTimeInterval(Double(nearlyFourteenDaysInSeconds)).toMilliseconds())"
         keychain.set(expiryDate, forKey: KeychainKey.refreshTokenExpiryDate.rawValue)
     }

--- a/RealifeTech-CoreSDK/APIV3Utilities/V3APITokenManager/OAuthTokenHelpers/AuthorisationWorker.swift
+++ b/RealifeTech-CoreSDK/APIV3Utilities/V3APITokenManager/OAuthTokenHelpers/AuthorisationWorker.swift
@@ -12,24 +12,45 @@ import RxSwift
 /// Used to request our OAuth token. When new tokens are received, this worker will save them to its store.
 protocol AuthorisationWorkable {
     var requestInitialAccessToken: Observable<OAuthToken> { get }
+    var refreshAccessToken: Observable<OAuthToken>? { get }
 }
 
 struct AuthorisationWorker: AuthorisationWorkable {
-    private var authorisationStore: AuthorisationStoring
-    private var oAuthRepositoryType: OAuthProviding.Type
 
-    init(authorisationStore: AuthorisationStoring, oAuthRepositoryType: OAuthProviding.Type = OAuthRepository.self) {
+    private let authorisationStore: AuthorisationStoring
+    private let oAuthRepositoryType: OAuthProviding.Type
+
+    init(
+        authorisationStore: AuthorisationStoring,
+        oAuthRepositoryType: OAuthProviding.Type = OAuthRepository.self
+    ) {
         self.authorisationStore = authorisationStore
         self.oAuthRepositoryType = oAuthRepositoryType
     }
 
     var requestInitialAccessToken: Observable<OAuthToken> {
-        return oAuthRepositoryType.requestInitialAccessToken()
-            .map { (token: OAuthToken) -> OAuthToken in
+        return mapAccessToken(with: oAuthRepositoryType.requestInitialAccessToken())
+    }
+
+    var refreshAccessToken: Observable<OAuthToken>? {
+        guard
+            authorisationStore.accessToken != nil,
+            !authorisationStore.accessTokenValid,
+            let refreshTokenToSend = authorisationStore.refreshToken
+        else {
+            return nil
+        }
+        return mapAccessToken(with: oAuthRepositoryType.refreshAccessToken(refreshTokenToSend))
+    }
+
+    private func mapAccessToken(with observable: Observable<OAuthToken>) -> Observable<OAuthToken> {
+        return observable
+            .map { token in
                 if let accessToken = token.accessToken, let expiresIn = token.expiresIn {
-                    self.authorisationStore.saveCredentials(
+                    authorisationStore.saveCredentials(
                         token: accessToken,
-                        secondsExpiresIn: expiresIn)
+                        secondsExpiresIn: expiresIn,
+                        refreshToken: token.refreshToken)
                 }
                 return token
         }

--- a/RealifeTech-CoreSDK/APIV3Utilities/V3APITokenManager/OAuthTokenHelpers/OAuthRefreshOrWaitActionGenerator.swift
+++ b/RealifeTech-CoreSDK/APIV3Utilities/V3APITokenManager/OAuthTokenHelpers/OAuthRefreshOrWaitActionGenerator.swift
@@ -34,8 +34,9 @@ struct OAuthRefreshOrWaitActionGenerator: OAuthRefreshOrWaitActionGenerating {
         } else if authorisationStore.accessTokenValid {
             return nil
         }
-        self.oAuthTokenRefreshWatcher.updateRefreshingStatus(newValue: .refreshing)
-        return authorisationWorker.requestInitialAccessToken
+        oAuthTokenRefreshWatcher.updateRefreshingStatus(newValue: .refreshing)
+        let refresh = authorisationWorker.refreshAccessToken ?? authorisationWorker.requestInitialAccessToken
+        return refresh
             .take(1)
             .do(onNext: { _ in
                 self.oAuthTokenRefreshWatcher.updateRefreshingStatus(newValue: .valid)

--- a/RealifeTech-CoreSDK/APIV3Utilities/V3APITokenManager/V3APITokenManagable.swift
+++ b/RealifeTech-CoreSDK/APIV3Utilities/V3APITokenManager/V3APITokenManagable.swift
@@ -12,19 +12,26 @@ import RxSwift
 public protocol V3APITokenManagable {
     var token: String? { get }
     var tokenIsValid: Bool { get }
-    /// Deprecated, please use func getValidToken where possible.
-    var getTokenObservable: Observable<Void>? { get }
+    var refreshToken: String? { get }
+    var refreshTokenIsValid: Bool { get }
 
     func getValidToken(_: (() -> Void)?)
+    func storeCredentials(accessToken: String, secondsExpiresIn: Int, refreshToken: String?)
+    func removeCredentials()
 }
 
 struct EmptyTokenManager: V3APITokenManagable {
 
     var token: String?
     var tokenIsValid: Bool = false
-    var getTokenObservable: Observable<Void>?
+    var refreshToken: String?
+    var refreshTokenIsValid: Bool = false
 
     func getValidToken(_ completion: (() -> Void)?) {
         completion?()
     }
+
+    func storeCredentials(accessToken: String, secondsExpiresIn: Int, refreshToken: String?) { }
+
+    func removeCredentials() { }
 }

--- a/RealifeTech-CoreSDK/APIV3Utilities/V3APITokenManager/V3APITokenManager.swift
+++ b/RealifeTech-CoreSDK/APIV3Utilities/V3APITokenManager/V3APITokenManager.swift
@@ -13,9 +13,8 @@ public class V3APITokenManager: V3APITokenManagable {
 
     public var token: String? { authorisationStore.accessToken }
     public var tokenIsValid: Bool { authorisationStore.accessTokenValid }
-    public var getTokenObservable: Observable<Void>? {
-        oAuthRefreshOrWaitActionGenerator.refreshTokenOrWaitAction
-    }
+    public var refreshToken: String? { authorisationStore.refreshToken }
+    public var refreshTokenIsValid: Bool { authorisationStore.refreshTokenValid }
 
     private let authorisationStore: AuthorisationStoring
     private let oAuthRefreshOrWaitActionGenerator: OAuthRefreshOrWaitActionGenerating
@@ -41,5 +40,16 @@ public class V3APITokenManager: V3APITokenManagable {
                 completion?()
             })
             .disposed(by: disposeBag)
+    }
+
+    public func storeCredentials(accessToken: String, secondsExpiresIn: Int, refreshToken: String?) {
+        authorisationStore.saveCredentials(
+            token: accessToken,
+            secondsExpiresIn: secondsExpiresIn,
+            refreshToken: refreshToken)
+    }
+
+    public func removeCredentials() {
+        authorisationStore.removeCredentials()
     }
 }

--- a/RealifeTech-CoreSDK/GraphQL/APIV3TokenInterceptor.swift
+++ b/RealifeTech-CoreSDK/GraphQL/APIV3TokenInterceptor.swift
@@ -32,7 +32,9 @@ class APIV3TokenInterceptor: ApolloInterceptor {
             return
         }
         if urlResponse.statusCode == 400 {
-            tokenHelper.getValidToken {
+            tokenHelper.getValidToken { [self] in
+                guard let token = tokenHelper.token, tokenHelper.tokenIsValid else { return }
+                request.addHeader(name: "Authorization", value: "Bearer \(token)")
                 chain.retry(request: request, completion: completion)
             }
         } else {

--- a/RealifeTech-CoreSDK/GraphQL/GraphNetworkInterceptorProvider.swift
+++ b/RealifeTech-CoreSDK/GraphQL/GraphNetworkInterceptorProvider.swift
@@ -19,8 +19,8 @@ struct GraphNetworkInterceptorProvider: InterceptorProvider {
             LegacyCacheReadInterceptor(store: store),
             NetworkFetchInterceptor(client: client),
             RequestLoggingInterceptor(),
-            ResponseCodeInterceptor(),
             APIV3TokenInterceptor(tokenHelper: tokenHelper),
+            ResponseCodeInterceptor(),
             LegacyParsingInterceptor(cacheKeyForObject: store.cacheKeyForObject),
             LegacyCacheWriteInterceptor(store: store)
         ]


### PR DESCRIPTION
**Issue 1**: GraphQLDspatcher keeps using invalid token even the APITokenManager refreshes the token successfully.

**Solution**: Move `APIV3TokenInterceptor` before `ResponseCodeInterceptor` in GraphNetworkInterceptorProvider so that the SDK is able to filter response code 400 before ResponseCodeInterceptor. And also add the correct token to the header in the interceptor.

**Issue 2**: In the frontier.ios, we have the logic of refreshAccessToken and requestInitialAccessToken. The former one is for the user who has `refresh_token` and the later one is for who has `access_token` only. We only handle the `requestInitialAccessToken` in the core sdk, but `refreshAccessToken` is required from backend's perspective.

**Solution**: Add `refreshToken` and its expiry date to keychain and they're saved when requesting the access token. `getValidToken` will make the call based on whether we have valid accessToken and refreshToken or not. If yes, makes the `refreshAccessCall`. If no, makes the `requestInitialAccessToken` call.