### PR TITLE
ID-964 ID-964 Expose error when requesting refreshToken fails	

### DIFF
--- a/RealifeTech-CoreSDK.podspec
+++ b/RealifeTech-CoreSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "RealifeTech-CoreSDK"
-  spec.version      = "1.0.8"
+  spec.version      = "1.0.9"
   spec.summary      = "Providing the core services with the RealifeTech Experience Automation Platform."
 
   spec.description  = "This is RealifeTech Core SDK, it provides the core services with RealifeTech backend services. Creating a better experience of the real world for every person."

--- a/RealifeTech-CoreSDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-CoreSDK.xcodeproj/project.pbxproj
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.8;
+				MARKETING_VERSION = 1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.concertlive.RealifeTech-CoreSDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1207,7 +1207,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.8;
+				MARKETING_VERSION = 1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.concertlive.RealifeTech-CoreSDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/RealifeTech-CoreSDK/APIUtilities/APIRequester.swift
+++ b/RealifeTech-CoreSDK/APIUtilities/APIRequester.swift
@@ -20,7 +20,7 @@ extension APIRequester {
 
     public static func preDispatchAction() -> Observable<Any?>? {
         return .create { observer in
-            APIRequesterHelper.tokenManager.getValidToken {
+            APIRequesterHelper.tokenManager.getValidToken { _ in
                 observer.onNext(())
                 observer.onCompleted()
             }

--- a/RealifeTech-CoreSDK/APIUtilities/APITokenManager/APITokenManagable.swift
+++ b/RealifeTech-CoreSDK/APIUtilities/APITokenManager/APITokenManagable.swift
@@ -15,7 +15,7 @@ public protocol APITokenManagable {
     var refreshToken: String? { get }
     var refreshTokenIsValid: Bool { get }
 
-    func getValidToken(_: (() -> Void)?)
+    func getValidToken(_: ((Result<Void, Error>) -> Void)?)
     func storeCredentials(accessToken: String, secondsExpiresIn: Int, refreshToken: String?)
     func removeCredentials()
 }
@@ -27,8 +27,8 @@ struct EmptyTokenManager: APITokenManagable {
     var refreshToken: String?
     var refreshTokenIsValid: Bool = false
 
-    func getValidToken(_ completion: (() -> Void)?) {
-        completion?()
+    func getValidToken(_ completion: ((Result<Void, Error>) -> Void)?) {
+        completion?(.success(()))
     }
 
     func storeCredentials(accessToken: String, secondsExpiresIn: Int, refreshToken: String?) { }

--- a/RealifeTech-CoreSDK/APIUtilities/APITokenManager/OAuthTokenHelpers/OAuthRefreshOrWaitActionGenerator.swift
+++ b/RealifeTech-CoreSDK/APIUtilities/APITokenManager/OAuthTokenHelpers/OAuthRefreshOrWaitActionGenerator.swift
@@ -49,6 +49,5 @@ struct OAuthRefreshOrWaitActionGenerator: OAuthRefreshOrWaitActionGenerating {
                 self.oAuthTokenRefreshWatcher.updateRefreshingStatus(newValue: .invalid)
             })
             .map { _ in return () }
-            .catchError { _ in return Observable.just(()) }
     }
 }

--- a/RealifeTech-CoreSDK/APIUtilities/Tests/APIRequesterTests.swift
+++ b/RealifeTech-CoreSDK/APIUtilities/Tests/APIRequesterTests.swift
@@ -124,8 +124,8 @@ private final class MockTokenManager: APITokenManagable {
     var refreshTokenIsValid: Bool = false
     var getTokenObservable: Observable<Void>?
 
-    func getValidToken(_ completion: (() -> Void)?) {
-        completion?()
+    func getValidToken(_ completion: ((Result<Void, Error>) -> Void)?) {
+        completion?(.success(()))
     }
 
     func storeCredentials(accessToken: String, secondsExpiresIn: Int, refreshToken: String?) { }

--- a/RealifeTech-CoreSDK/APIUtilities/Tests/APITokenManagerTests.swift
+++ b/RealifeTech-CoreSDK/APIUtilities/Tests/APITokenManagerTests.swift
@@ -54,7 +54,7 @@ final class APITokenManagerTests: XCTestCase {
     func test_getValidToken_noDelay() {
         testRefreshGenerator.refreshTokenOrWaitAction = nil
         var synchronousCompletionCheck = false
-        sut.getValidToken { synchronousCompletionCheck = true }
+        sut.getValidToken { _ in synchronousCompletionCheck = true }
         XCTAssertTrue(synchronousCompletionCheck)
     }
 
@@ -62,7 +62,7 @@ final class APITokenManagerTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Valid token completion called")
         let observableSource = PublishSubject<Void>.just(())
         testRefreshGenerator.refreshTokenOrWaitAction = observableSource.asObservable()
-        sut.getValidToken {
+        sut.getValidToken { _ in
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 0.01)

--- a/RealifeTech-CoreSDK/APIUtilities/Tests/EmptyTokenManagerTests.swift
+++ b/RealifeTech-CoreSDK/APIUtilities/Tests/EmptyTokenManagerTests.swift
@@ -14,7 +14,7 @@ final class EmptyTokenManagerTests: XCTestCase {
     func test_getValidToken() {
         let sut = EmptyTokenManager()
         var didExecuteCompletion: Bool = false
-        sut.getValidToken {
+        sut.getValidToken { _ in
             didExecuteCompletion = true
         }
         XCTAssertTrue(didExecuteCompletion)

--- a/RealifeTech-CoreSDK/CoreFactory.swift
+++ b/RealifeTech-CoreSDK/CoreFactory.swift
@@ -64,7 +64,7 @@ public enum CoreFactory {
     ///  completion: Optional closure with default nil value
     public static func requestValidToken(
         fromApiHelper apiHelper: APITokenManagable,
-        completion: (() -> Void)? = nil
+        completion: ((Result<Void, Error>) -> Void)? = nil
     ) {
         apiHelper.getValidToken(completion)
     }

--- a/RealifeTech-CoreSDK/GraphQL/APITokenInterceptor.swift
+++ b/RealifeTech-CoreSDK/GraphQL/APITokenInterceptor.swift
@@ -32,7 +32,7 @@ class APITokenInterceptor: ApolloInterceptor {
             return
         }
         if urlResponse.statusCode == 400 {
-            tokenHelper.getValidToken { [self] in
+            tokenHelper.getValidToken { [self] _ in
                 guard let token = tokenHelper.token, tokenHelper.tokenIsValid else { return }
                 request.addHeader(name: "Authorization", value: "Bearer \(token)")
                 chain.retry(request: request, completion: completion)


### PR DESCRIPTION
We could just expose a boolean value to let the users know if the call is successful or not. However, I think exposing the `error` provides more flexibility to the users.