### PR TITLE
ID-971 App sends simultaneous POST /v3/oauth/v2/token calls

### DIFF
--- a/RealifeTech-CoreSDK.podspec
+++ b/RealifeTech-CoreSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "RealifeTech-CoreSDK"
-  spec.version      = "1.0.9"
+  spec.version      = "1.0.10"
   spec.summary      = "Providing the core services with the RealifeTech Experience Automation Platform."
 
   spec.description  = "This is RealifeTech Core SDK, it provides the core services with RealifeTech backend services. Creating a better experience of the real world for every person."

--- a/RealifeTech-CoreSDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-CoreSDK.xcodeproj/project.pbxproj
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.concertlive.RealifeTech-CoreSDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1207,7 +1207,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.9;
+				MARKETING_VERSION = 1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.concertlive.RealifeTech-CoreSDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/RealifeTech-CoreSDK/APIUtilities/APITokenManager/APITokenManager.swift
+++ b/RealifeTech-CoreSDK/APIUtilities/APITokenManager/APITokenManager.swift
@@ -19,7 +19,7 @@ public class APITokenManager: APITokenManagable {
     private let authorisationStore: AuthorisationStoring
     private let oAuthRefreshOrWaitActionGenerator: OAuthRefreshOrWaitActionGenerating
     private let scheduler: SchedulerType
-    private let disposeBag: DisposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
 
     init(
         authorisationStore: AuthorisationStoring,

--- a/RealifeTech-CoreSDK/APIUtilities/APITokenManager/OAuthTokenHelpers/OAuthRefreshOrWaitActionGenerator.swift
+++ b/RealifeTech-CoreSDK/APIUtilities/APITokenManager/OAuthTokenHelpers/OAuthRefreshOrWaitActionGenerator.swift
@@ -37,7 +37,7 @@ struct OAuthRefreshOrWaitActionGenerator: OAuthRefreshOrWaitActionGenerating {
             return nil
         }
         if let ongoingTokenRefresh = oAuthTokenRefreshWatcher.ongoingTokenRefresh {
-            // We take 1 because we only care about the current refresh.
+            // We take the last one because we only care about the current refresh.
             return ongoingTokenRefresh.takeLast(1).map { _ in return () }
         }
         oAuthTokenRefreshWatcher.updateRefreshingStatus(newValue: .refreshing)

--- a/RealifeTech-CoreSDK/APIUtilities/APITokenManager/OAuthTokenHelpers/OAuthRefreshOrWaitActionGenerator.swift
+++ b/RealifeTech-CoreSDK/APIUtilities/APITokenManager/OAuthTokenHelpers/OAuthRefreshOrWaitActionGenerator.swift
@@ -33,16 +33,17 @@ struct OAuthRefreshOrWaitActionGenerator: OAuthRefreshOrWaitActionGenerating {
     /// Nil if we have a valid token. If no token exists, or is invalid, or is being currently refreshed,
     /// this will return an observable which will emit once the token action is complete.
     var refreshTokenOrWaitAction: Observable<Void>? {
+        if authorisationStore.accessTokenValid {
+            return nil
+        }
         if let ongoingTokenRefresh = oAuthTokenRefreshWatcher.ongoingTokenRefresh {
             // We take 1 because we only care about the current refresh.
-            return ongoingTokenRefresh.take(1).map { _ in return () }
-        } else if authorisationStore.accessTokenValid {
-            return nil
+            return ongoingTokenRefresh.takeLast(1).map { _ in return () }
         }
         oAuthTokenRefreshWatcher.updateRefreshingStatus(newValue: .refreshing)
         let refresh = authorisationWorker.refreshAccessToken ?? authorisationWorker.requestInitialAccessToken
         return refresh
-            .take(1)
+            .takeLast(1)
             .do(onNext: { _ in
                 self.oAuthTokenRefreshWatcher.updateRefreshingStatus(newValue: .valid)
             }, onError: { _ in

--- a/RealifeTech-CoreSDK/APIUtilities/Tests/OAuthRefreshOrWaitActionGeneratorTests.swift
+++ b/RealifeTech-CoreSDK/APIUtilities/Tests/OAuthRefreshOrWaitActionGeneratorTests.swift
@@ -37,9 +37,9 @@ final class OAuthRefreshOrWaitActionGeneratorTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let disposeBag = DisposeBag()
         let refreshCompleteStream = scheduler.createColdObservable([
-            Recorded.next(100, true),
-            Recorded.next(300, true),
-            Recorded.completed(500)])
+            Recorded.next(10, true),
+            Recorded.next(30, true),
+            Recorded.completed(30)])
         let watcher = MockWatcher()
         watcher.ongoingTokenRefresh = refreshCompleteStream.asObservable()
         let store = MockStore()
@@ -58,20 +58,20 @@ final class OAuthRefreshOrWaitActionGeneratorTests: XCTestCase {
         scheduler.start()
 
         let expectedEvents = [
-            Recorded.next(500, true),
-            Recorded.completed(500)
+            Recorded.next(30, true),
+            Recorded.completed(30)
         ]
         XCTAssertEqual(expectedEvents, observer.events)
     }
 
     func test_refreshOrWaitAction_getToken_success() throws {
         let inputEvents = [
-            Recorded.next(100, emptyToken),
-            Recorded.next(300, emptyToken),
-            Recorded.completed(500)]
+            Recorded.next(10, emptyToken),
+            Recorded.next(30, emptyToken),
+            Recorded.completed(30)]
         let refreshEvents = [
-            Recorded.next(500, true),
-            Recorded.completed(500)]
+            Recorded.next(30, true),
+            Recorded.completed(30)]
         let tokenStatuses = [
             OAuthTokenStatus.refreshing,
             OAuthTokenStatus.valid]
@@ -83,10 +83,10 @@ final class OAuthRefreshOrWaitActionGeneratorTests: XCTestCase {
 
     func test_refreshOrWaitAction_getToken_failure() throws {
         let inputEvents: [Recorded<Event<OAuthToken>>] = [
-            Recorded.error(100, MockError())]
+            Recorded.error(10, MockError())]
         let refreshEvents = [
-            Recorded.next(100, true),
-            Recorded.completed(100)]
+            Recorded.next(10, true),
+            Recorded.completed(10)]
         let tokenStatuses = [
             OAuthTokenStatus.refreshing,
             OAuthTokenStatus.invalid]


### PR DESCRIPTION
Taking the last refreshing observable instead of taking the first one resolves the issue.