### PR TITLE
ID-1023 Change the db file directory

### DIFF
--- a/RealifeTech-CoreSDK.podspec
+++ b/RealifeTech-CoreSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "RealifeTech-CoreSDK"
-  spec.version      = "1.0.10"
+  spec.version      = "1.0.11"
   spec.summary      = "Providing the core services with the RealifeTech Experience Automation Platform."
 
   spec.description  = "This is RealifeTech Core SDK, it provides the core services with RealifeTech backend services. Creating a better experience of the real world for every person."

--- a/RealifeTech-CoreSDK.xcodeproj/project.pbxproj
+++ b/RealifeTech-CoreSDK.xcodeproj/project.pbxproj
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.10;
+				MARKETING_VERSION = 1.0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.concertlive.RealifeTech-CoreSDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1207,7 +1207,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.10;
+				MARKETING_VERSION = 1.0.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.concertlive.RealifeTech-CoreSDK";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/RealifeTech-CoreSDK/GraphQL/GraphNetwork.swift
+++ b/RealifeTech-CoreSDK/GraphQL/GraphNetwork.swift
@@ -45,7 +45,7 @@ public class GraphNetwork {
 
     private lazy var store: ApolloStore = {
         let documentsPath = NSSearchPathForDirectoriesInDomains(
-            .documentDirectory,
+            .libraryDirectory,
             .userDomainMask,
             true).first ?? ""
         let documentsUrl = URL(fileURLWithPath: documentsPath)


### PR DESCRIPTION
### Investigation:
The crashing point is `disk I/O error (code: 10)` from ApolloStore.
The crashing won't happen if we comment out `ticketmasterManager.fetchTickets(email:, presenter:, delegate)`, so the crashing is definitely relevant to Ticketmaster SDK.

### Solution:
Changing the directory of the SQLite DB file fixes the crashing on Ticketmaster SDK. 

### Analysis:
I really have no idea how this resolves another SDK, but I reckoned that Ticketmaster SDK may use SQLite to have the offline tickets mode. Ticketmaster SDK probably uses the same `documentDirectory` which is the same path as the Apollo and it clears the directory when calling `ticketmasterManager.fetchTickets(email:, presenter:, delegate)`. Therefore, the `disk I/O error` happens when the app tries to query the Canvas via Apollo.

I couldn't find any SQLite related codes from Ticketmaster SDK, so it's all my guess.
